### PR TITLE
Dispatching an event after creating or editing an instance

### DIFF
--- a/src/Admin/Accions/AdminEditInstance2.php
+++ b/src/Admin/Accions/AdminEditInstance2.php
@@ -2,6 +2,8 @@
 
 namespace Omatech\Editora\Admin\Accions;
 
+use Illuminate\Support\Facades\Event;
+use Omatech\Editora\Admin\Events\NewInstance2InsertedEvent;
 use Omatech\Editora\Admin\Models\attributes;
 use Omatech\Editora\Admin\Models\Instances;
 use Omatech\Editora\Admin\Models\Security;
@@ -81,6 +83,7 @@ class AdminEditInstance2 extends AuthController
 
                 $inst_id=$params['param2'];
                 $instances->instance_update_date_and_backup($inst_id);
+                $this->dispatchEvent((int) $inst_id);
             }
 
             $parents=$ly_t->paintParentsList($instances->getParents($params), $params);
@@ -106,5 +109,14 @@ class AdminEditInstance2 extends AuthController
                 return response()->view('editora::pages.instance', $viewData);
                 break;
         }
+    }
+
+    private function dispatchEvent(int $instanceId): void
+    {
+        try {
+            if ($instanceId !== 0) {
+                Event::dispatch(new NewInstance2InsertedEvent($instanceId));
+            }
+        }catch (\Exception $exception) {}
     }
 }

--- a/src/Admin/Accions/AdminEditInstance2.php
+++ b/src/Admin/Accions/AdminEditInstance2.php
@@ -3,7 +3,7 @@
 namespace Omatech\Editora\Admin\Accions;
 
 use Illuminate\Support\Facades\Event;
-use Omatech\Editora\Admin\Events\NewInstance2InsertedEvent;
+use Omatech\Editora\Admin\Events\EditInstance2UpdatedEvent;
 use Omatech\Editora\Admin\Models\attributes;
 use Omatech\Editora\Admin\Models\Instances;
 use Omatech\Editora\Admin\Models\Security;
@@ -115,7 +115,7 @@ class AdminEditInstance2 extends AuthController
     {
         try {
             if ($instanceId !== 0) {
-                Event::dispatch(new NewInstance2InsertedEvent($instanceId));
+                Event::dispatch(new EditInstance2UpdatedEvent($instanceId));
             }
         }catch (\Exception $exception) {}
     }

--- a/src/Admin/Accions/AdminNewInstance2.php
+++ b/src/Admin/Accions/AdminNewInstance2.php
@@ -2,7 +2,9 @@
 
 namespace Omatech\Editora\Admin\Accions;
 
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Session;
+use Omatech\Editora\Admin\Events\NewInstance2InsertedEvent;
 use Omatech\Editora\Admin\Models\Security;
 use Omatech\Editora\Admin\Models\Instances;
 use Omatech\Editora\Admin\Models\Relations;
@@ -99,6 +101,7 @@ class AdminNewInstance2 extends AuthController
                 $inst_id = $params['param2'];
                 $instances->instance_update_date_and_backup($inst_id);
                 $_REQUEST['view'] = 'container';
+                $this->dispatchEvent((int) $inst_id);
                 return redirect(route('editora.action', 'view_instance?p_pagina=1&p_class_id='.$redirect_class_id.'&p_inst_id='.$redirect_inst_id));
             }
         }
@@ -115,5 +118,14 @@ class AdminNewInstance2 extends AuthController
         ]);
 
         return response()->view('editora::pages.instance', $viewData);
+    }
+
+    private function dispatchEvent(int $instanceId): void
+    {
+        try {
+            if ($instanceId !== 0) {
+                Event::dispatch(new NewInstance2InsertedEvent($instanceId));
+            }
+        }catch (\Exception $exception) {}
     }
 }

--- a/src/Admin/Events/EditInstance2UpdatedEvent.php
+++ b/src/Admin/Events/EditInstance2UpdatedEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Omatech\Editora\Admin\Events;
+
+class EditInstance2UpdatedEvent
+{
+    public $instanceId;
+
+    public function __construct(int $instanceId)
+    {
+        $this->instanceId = $instanceId;
+    }
+}

--- a/src/Admin/Events/NewInstance2InsertedEvent.php
+++ b/src/Admin/Events/NewInstance2InsertedEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Omatech\Editora\Admin\Events;
+
+class NewInstance2InsertedEvent
+{
+    public $instanceId;
+
+    public function __construct(int $instanceId)
+    {
+        $this->instanceId = $instanceId;
+    }
+}


### PR DESCRIPTION
When a new instance is created/edited in the CMS, in some Laravel projects we need to perform some specific action. To detect the moment to perform the action, an event is now launched.

The only information of these events is the ID of the instance.